### PR TITLE
APPS-1766 Ignore plugin change error.

### DIFF
--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -15,6 +15,7 @@
 #define DZN_IS_LANDSCAPE ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeLeft || [UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeRight)
 
 static char DZNWebViewControllerKVOContext = 0;
+const int isPluginHandledError  = 204;
 
 @interface DZNWebViewController ()
 
@@ -419,7 +420,9 @@ static char DZNWebViewControllerKVOContext = 0;
 {
     switch (error.code) {
         case NSURLErrorUnknown:
-        case NSURLErrorCancelled:   return;
+        case NSURLErrorCancelled:
+        case isPluginHandledError: // When there is a plugin in error ignore it, as the content will continue to play.
+            return;
     }
     
     [[UIApplication sharedApplication] setNetworkActivityIndicatorVisible:NO];

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -15,7 +15,7 @@
 #define DZN_IS_LANDSCAPE ([UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeLeft || [UIApplication sharedApplication].statusBarOrientation == UIInterfaceOrientationLandscapeRight)
 
 static char DZNWebViewControllerKVOContext = 0;
-const int isPluginHandledError  = 204;
+const int KPLUGINHANDLEDERROR  = 204;
 
 @interface DZNWebViewController ()
 
@@ -421,7 +421,7 @@ const int isPluginHandledError  = 204;
     switch (error.code) {
         case NSURLErrorUnknown:
         case NSURLErrorCancelled:
-        case isPluginHandledError: // When there is a plugin in error ignore it, as the content will continue to play.
+        case KPLUGINHANDLEDERROR: // When there is a plugin in error ignore it, as the content will continue to play.
             return;
     }
     


### PR DESCRIPTION
**What is the Issue?** 
Whenever a HLS Video is played, we are getting an error "Plug in handled error". This is happening even with safari browser, when we inspect the data in console and this isn't an issue only with app. 

**Fix Provided**
Current logic handles all errors. so for all HLS Video's an error would be displayed along with an error. This PR ignores the error "Plugin Handled error".

**Investigations and Findings**
Also this issue is not there only from frankly contents, it is there for contents downloaded from open source as well. So we can be sure that this is neither a problem with the way `video is transcoded from our side` nor a `problem with the way app is handling it`, instead this seems to be at OS level. Following exercise has been done to back this finding, 

We are loading web page inside app, for this specific content. This is equivalent to accessing content from Safari bowser. Since we are seeing the error in safari we can be pretty sure that this specific issue is in the OS level. I am attaching a screen shot from safari.

<img width="1792" alt="Screenshot 2020-06-17 at 4 42 13 PM" src="https://user-images.githubusercontent.com/65164881/84891810-1ae76780-b0ba-11ea-9c8e-661fa68c79a1.png">

https://worldnow.atlassian.net/browse/APPS-1766 This ticket has the corresponding bug.